### PR TITLE
Make it a Clojure CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ clj -Sdeps '{:deps {io.github.borkdude/lein2deps {:git/sha "..."}}}' \
     -M -m lein2deps.api --print --write-file deps.edn
 ```
 
+With Clojure CLI Tools:
+
+``` shell
+clojure -Ttools install-latest :lib io.github.borkdude/lein2deps :as lein2deps
+
+clojure -Tlein2deps lein2deps :print true :write-file "deps.edn"
+```
+
 ## Java compilation
 
 This tool respects `:java-source-paths` in `project.clj` and adds a `:deps/prep-lib`

--- a/deps.edn
+++ b/deps.edn
@@ -3,6 +3,7 @@
         borkdude/edamame {:mvn/version "1.0.0"}
         io.github.clojure/tools.build
         {:git/sha "984a24c0ef0a6af3f304b567adb45af40baefd08"}}
+ :tools/usage {:ns-default lein2deps.api}
  :aliases
  {:test ;; added by neil
   {:extra-paths ["test"]

--- a/src/lein2deps/api.clj
+++ b/src/lein2deps/api.clj
@@ -44,7 +44,7 @@
                    (add-prep-lib project-edn)
                    (seq dev-deps) (assoc-in [:aliases :dev :extra-deps] dev-deps))]
     (when-let [f (:write-file opts)]
-      (spit f (with-out-str (pprint/pprint deps-edn))))
+      (spit (str f) (with-out-str (pprint/pprint deps-edn))))
     (when (:print opts)
       (pprint/pprint deps-edn))
     {:deps deps-edn }))


### PR DESCRIPTION
Would be nice if I could install lein2deps as a Clojure CLI tool.

Maybe it's as simple as adding `:tools/usage {:ns-default lein2deps.api}` to `deps.edn`?