### PR TITLE
Convert project.clj :repositories to deps.edn :mvn/repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## Unreleased
 
 - Fix [#2](https://github.com/borkdude/lein2deps/issues/2): accept regex in `project.clj` when safe-parsing
-
+- Fix [#4](https://github.com/borkdude/lein2deps/issues/4): convert `:repositories` to `:mvn/repos`

--- a/src/lein2deps/api.clj
+++ b/src/lein2deps/api.clj
@@ -29,7 +29,7 @@
         project-edn (merge {:compile-path "target/classes"
                             :source-paths ["src"]}
                            project-edn)
-        {:keys [dependencies source-paths resource-paths compile-path java-source-paths]} project-edn
+        {:keys [dependencies source-paths resource-paths compile-path java-source-paths repositories]} project-edn
         deps (map convert-dep dependencies)
         dev-deps (into {} (keep #(when (= :dev (:alias (second %)))
                                    [(first %) (dissoc (second %) :alias)])
@@ -42,6 +42,7 @@
         deps-edn (cond-> deps-edn
                    java-source-paths
                    (add-prep-lib project-edn)
+                   (seq repositories) (assoc :mvn/repos (into {} repositories))
                    (seq dev-deps) (assoc-in [:aliases :dev :extra-deps] dev-deps))]
     (when-let [f (:write-file opts)]
       (spit (str f) (with-out-str (pprint/pprint deps-edn))))


### PR DESCRIPTION
I wasn't sure what's the max line length. It's wide with the extra
repositories destructuring key in there.