### PR TITLE
Improve quality of generated deps.edn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [#7](https://github.com/borkdude/lein2deps/issues/7): maintain order of deps in `project.clj` and no namespacing of maps
 - [#2](https://github.com/borkdude/lein2deps/issues/2): accept regex in `project.clj` when safe-parsing
 - [#3](https://github.com/borkdude/lein2deps/issues/3): add clojure -Ttool support
 - [#4](https://github.com/borkdude/lein2deps/issues/4): convert `:repositories` to `:mvn/repos`

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
         org.babashka/cli {:mvn/version "0.5.40"}
         borkdude/edamame {:mvn/version "1.0.0"}
         io.github.clojure/tools.build
-        {:git/sha "984a24c0ef0a6af3f304b567adb45af40baefd08"}}
+        {:git/sha "984a24c0ef0a6af3f304b567adb45af40baefd08"}
+        org.flatland/ordered {:mvn/version "1.15.10"}}
  :tools/usage {:ns-default lein2deps.api}
  :aliases
  {:test ;; added by neil

--- a/src/lein2deps/api.clj
+++ b/src/lein2deps/api.clj
@@ -3,6 +3,7 @@
    [babashka.cli :as cli]
    [babashka.fs :as fs]
    [clojure.pprint :as pprint]
+   [flatland.ordered.map :refer [ordered-map]]
    [lein2deps.internal :refer [safe-parse convert-dep
                                add-prep-lib
                                #_:clj-kondo/ignore
@@ -31,10 +32,10 @@
                            project-edn)
         {:keys [dependencies source-paths resource-paths compile-path java-source-paths repositories]} project-edn
         deps (map convert-dep dependencies)
-        dev-deps (into {} (keep #(when (= :dev (:alias (second %)))
-                                   [(first %) (dissoc (second %) :alias)])
-                                deps))
-        deps (into {} (remove (comp :alias second) deps))
+        dev-deps (into (ordered-map) (keep #(when (= :dev (:alias (second %)))
+                                              [(first %) (dissoc (second %) :alias)])
+                                           deps))
+        deps (into (ordered-map) (remove (comp :alias second) deps))
         deps-edn {:paths (cond-> (into (vec source-paths) resource-paths)
                            java-source-paths
                            (conj compile-path))

--- a/src/lein2deps/api.clj
+++ b/src/lein2deps/api.clj
@@ -2,12 +2,12 @@
   (:require
    [babashka.cli :as cli]
    [babashka.fs :as fs]
-   [clojure.pprint :as pprint]
    [flatland.ordered.map :refer [ordered-map]]
    [lein2deps.internal :refer [safe-parse convert-dep
                                add-prep-lib
                                #_:clj-kondo/ignore
-                               defproject]]))
+                               defproject
+                               pprint]]))
 
 (defn lein2deps
   "Converts project.clj to deps.edn.
@@ -46,9 +46,9 @@
                    (seq repositories) (assoc :mvn/repos (into {} repositories))
                    (seq dev-deps) (assoc-in [:aliases :dev :extra-deps] dev-deps))]
     (when-let [f (:write-file opts)]
-      (spit (str f) (with-out-str (pprint/pprint deps-edn))))
+      (spit (str f) (with-out-str (pprint deps-edn))))
     (when (:print opts)
-      (pprint/pprint deps-edn))
+      (pprint deps-edn))
     {:deps deps-edn }))
 
 (defn -main

--- a/src/lein2deps/internal.clj
+++ b/src/lein2deps/internal.clj
@@ -1,5 +1,6 @@
 (ns lein2deps.internal
   (:require
+   [clojure.pprint :as pprint]
    [clojure.walk :as walk]
    [edamame.core :as e]))
 
@@ -56,3 +57,7 @@
            {:ensure compile-path
             :alias :lein2deps
             :fn 'compile-java})))
+
+(defn pprint [x]
+  (binding [*print-namespace-maps* false]
+    (pprint/pprint x)))

--- a/test/lein2deps/api_test.clj
+++ b/test/lein2deps/api_test.clj
@@ -39,3 +39,28 @@
                  [org.clojure/test.check \"1.0.13\" :scope \"provided\"]]
   :regex #\"foo\")"}))]
     (is (= "1.0.0" (-> deps :deps (get 'cheshire/cheshire) :mvn/version)))))
+
+(deftest maintain-ordered-test
+  (let [orig-deps (mapv (fn [i] (symbol "d" (str "dep" i))) (shuffle (range 10)))
+        deps-in-order (pr-str (into []
+                                    (concat (mapv (fn [dep] [dep "0.0.1"]) orig-deps)
+                                            ;; dev deps
+                                            (mapv (fn [dep] [dep "0.0.2" :scope "provided"]) orig-deps))))
+        project-clj (str "
+(defproject dude/foo \"0.0.1\"
+  :dependencies " deps-in-order ")")]
+    (let [deps (:deps (lein2deps {:project-clj project-clj}))]
+      (is (= orig-deps (-> deps :deps (keys))))
+      (is (= orig-deps (-> deps :aliases :dev :extra-deps (keys)))))
+
+    (let [deps (:deps (lein2deps {:eval true
+                                  :project-clj project-clj}))]
+      (is (= orig-deps (-> deps :deps (keys))))
+      (is (= orig-deps (-> deps :aliases :dev :extra-deps (keys)))))))
+
+(deftest prevent-namespacing-test
+  (let [output (with-out-str (lein2deps {:print true
+                                         :project-clj "
+(defproject dude/foo \"0.0.1\"
+  :dependencies [[cheshire \"1.0.0\"]])"}))]
+    (is (clojure.string/includes? output "cheshire/cheshire {:mvn/version \"1.0.0\"}"))))


### PR DESCRIPTION
This change tries to improve the quality the generated deps.edn by

- maintaining the order of the deps in the `project.clj` file
- not printing namespace maps

Resolves #7 

An example of this update can be seen in [this diff](https://github.com/clj-commons/aleph/compare/a282af98817a89cba109b420ea5c8ae8b44ff0d6...jeroenvandijk:aleph:lein2deps-issue-7?expand=1)

I'm not sure what version of `lein2deps` was used before I notice the previous deps.edn had the warning at the top and didn't have the repos output. But if use the current master and then view the diff it is only the dependency order and map printing.