### PR TITLE
Set the :fn option when calling the edamame parser

### DIFF
--- a/src/lein2deps/internal.clj
+++ b/src/lein2deps/internal.clj
@@ -16,11 +16,13 @@
 (defn safe-parse [input]
   (let [parser (e/reader input)
         cfg {:read-eval identity
-             :regex true}
+             :regex true
+             :fn true}
         form (first (take-while #(or
                                   (and (seq? %)
                                        (= 'defproject (first %)))
-                                  (= ::e/eof %)) (repeatedly #(e/parse-next parser cfg))))
+                                  (= ::e/eof %))
+                                (repeatedly #(e/parse-next parser cfg))))
         project-clj-edn form]
     (apply hash-map (drop 3 project-clj-edn))))
 


### PR DESCRIPTION
This option is necessary to parse content which is of a `function` form -- something that opens with a `(` character. Without passing this option, we will always hit the following error:

    Type:     clojure.lang.ExceptionInfo
    Message:  Function literal not allowed. Use the `:fn` option
    Data:     {:type :edamame/error, nil 30}
    Location:
    .../lein2deps/4f6d4a0140ddea10c5ac28cc24b49643660f42f6/src/lein2deps/internal.clj:23:63

Closes: #10