### PR TITLE
Fix support for string repo values

### DIFF
--- a/src/lein2deps/api.clj
+++ b/src/lein2deps/api.clj
@@ -9,6 +9,15 @@
                                defproject
                                pprint]]))
 
+(defn ^:private repositories->repos
+  [repositories]
+  (into {}
+    (map (fn [[repo-name repo-spec]]
+           (if (string? repo-spec)
+             [repo-name {:url repo-spec}]
+             [repo-name repo-spec])))
+    repositories))
+
 (defn lein2deps
   "Converts project.clj to deps.edn.
 
@@ -44,7 +53,7 @@
         deps-edn (cond-> deps-edn
                    java-source-paths
                    (add-prep-lib project-edn)
-                   (seq repositories) (assoc :mvn/repos (into {} repositories))
+                   (seq repositories) (assoc :mvn/repos (repositories->repos repositories))
                    (seq dev-deps) (assoc-in [:aliases :dev :extra-deps] dev-deps))]
     (when-let [f (:write-file opts)]
       (spit (str f) (with-out-str (pprint deps-edn))))


### PR DESCRIPTION
Leiningen allows repo definitions to be either strings (e.g. `"https://download.java.net/maven/2"`) or maps (`{:url "https://download.java.net/maven/2"}`). `deps.edn` only allows maps, so if `project.clj` has a string, we'll need to convert it into a map.